### PR TITLE
Add warn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ const FlowWebpackPlugin = require('flow-webpack-plugin')
 new FlowWebpackPlugin({
     failOnError: false,
     failOnErrorWatch: false,
+    warn: false,
     printFlowOutput: true,
     flowPath: require.main.require('flow-bin'),
     flowArgs: ['--color=always'],
@@ -75,6 +76,7 @@ new FlowWebpackPlugin({
 | --- | --- | --- | --- |
 | `failOnError` | `boolean` | `false` | Webpack exits with non-zero error code if flow typechecking fails. |
 | `failOnErrorWatch` | `boolean` | `false` | Webpack in watch mode exits with non-zero error code if flow typechecking fails. |
+| `warn` | `boolean` | `false` | Output warning instead of error if flow typechecking fails. |
 | `printFlowOutput` | `boolean` | `true` | `true` ~ Output of `flow` is printed at the end of webpack compilation in case of error, `false` ~ output of `flow` is discarded. |
 | `flowPath` | `string` | `require('flow-bin')` if `flow-bin` package is installed. Otherwise the parameter is required. | Path to flow executable. It may be both absolute, relative to the 'cwd' of webpack process or just name of an executable on the PATH.
 | `flowArgs` | `Array<string>` | `['--color=always']` if standard output is directed to a terminal, otherwise `[]` | Flow command line arguments. See [flow cli documentation][1]. |

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ type CallbackType = (FlowResult) => ?Promise<any>
 interface Options {
     failOnError: boolean,
     failOnErrorWatch: boolean,
+    warn: boolean,
     printFlowOutput: boolean,
     flowPath: string,
     flowArgs: Array<string>,
@@ -98,7 +99,8 @@ FlowWebpackPlugin.prototype.apply = function(compiler) {
         }
 
         const details = plugin.options.printFlowOutput ? (EOL + formatFlowOutput(flowResult)) : ''
-        compilation.errors.push('Flow validation' + details)
+        const errorsOrWarnings = plugin.options.warn ? 'warnings' : 'errors'
+        compilation[errorsOrWarnings].push('Flow validation' + details)
         callback()
     })
 


### PR DESCRIPTION
I'd like to not fail the build while there are flow errors for rapid iteration, but I still want to see them.